### PR TITLE
Fix KeysError when field name is not unique on the form

### DIFF
--- a/aldryn_forms/models.py
+++ b/aldryn_forms/models.py
@@ -356,6 +356,9 @@ class FieldsetPlugin(CMSPlugin):
 
 @python_2_unicode_compatible
 class FieldPluginBase(CMSPlugin):
+
+    unique_field_name = True  # Ensure that `name` is the unique input in the form. Used in class UniqueFieldNameMixin.
+
     name = models.CharField(
         _('Name'),
         max_length=255,

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ REQUIREMENTS = [
     'django-sizefield',
     'openpyxl<=2.4.9',  # 2.5.0b1 is raising "ImportError: cannot import name '__version__'"
     'six>=1.0',
+    'django-simple-captcha',
 ]
 
 

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,0 +1,93 @@
+from django import forms as django_forms
+from django.forms.models import modelform_factory
+
+from cms.api import add_plugin, create_page
+from cms.test_utils.testcases import CMSTestCase
+
+from aldryn_forms import forms, models
+
+
+class UniqueFieldNameMixinTest(CMSTestCase):
+
+    def setUp(self):
+        page = create_page('test page', 'test_page.html', 'en')
+        self.placeholder = page.placeholders.get(slot='content')
+        self.form = add_plugin(self.placeholder, 'FormPlugin', 'en')
+        add_plugin(self.form.placeholder, 'TextField', 'en', target=self.form, name="first_name")
+        add_plugin(self.form.placeholder, 'TextField', 'en', target=self.form, name="last_name")
+        descendant = add_plugin(self.form.placeholder, 'PlaceholderPlugin', 'en', target=self.form)
+        self.email = add_plugin(self.form.placeholder, 'EmailField', 'en', target=descendant, name="email")
+
+    def test_clean_name(self):
+        mixin = forms.UniqueFieldNameMixin()
+        mixin.instance = self.email
+        mixin.cleaned_data = {'name': 'email'}
+        mixin.clean_name()
+        self.assertEquals(mixin.instance.name, "email")
+
+    def _test_not_unique_field_name(self, field):
+        field.instance = add_plugin(self.placeholder, 'EmailField', 'en', target=self.form, name="email")
+        field.cleaned_data = {'name': 'email'}
+        message = 'This field name is already used in the form. Please select another.'
+        with self.assertRaisesMessage(django_forms.ValidationError, message):
+            field.clean_name()
+
+    def test_unique_field_mixin(self):
+        self._test_not_unique_field_name(forms.UniqueFieldNameMixin())
+
+    def test_restricted_file_field(self):
+        self._test_not_unique_field_name(forms.RestrictedFileField())
+
+    def test_restricted_image_field(self):
+        self._test_not_unique_field_name(forms.RestrictedImageField())
+
+    def test_boolean_field_form(self):
+        Field = modelform_factory(models.FieldPlugin, forms.BooleanFieldForm)
+        self._test_not_unique_field_name(Field())
+
+    def test_select_field_form(self):
+        Field = modelform_factory(models.FieldPlugin, forms.SelectFieldForm)
+        self._test_not_unique_field_name(Field())
+
+    def test_radio_field_form(self):
+        Field = modelform_factory(models.FieldPlugin, forms.RadioFieldForm)
+        self._test_not_unique_field_name(Field())
+
+    def test_captcha_field_form(self):
+        Field = modelform_factory(models.FieldPlugin, forms.CaptchaFieldForm)
+        self._test_not_unique_field_name(Field())
+
+    def test_min_max_value_form(self):
+        Field = modelform_factory(models.FieldPlugin, forms.MinMaxValueForm, exclude=[])
+        self._test_not_unique_field_name(Field())
+
+    def test_text_field_form(self):
+        Field = modelform_factory(models.FieldPlugin, forms.TextFieldForm)
+        self._test_not_unique_field_name(Field())
+
+    def test_hidden_field_form(self):
+        Field = modelform_factory(models.FieldPlugin, forms.HiddenFieldForm)
+        self._test_not_unique_field_name(Field())
+
+    def test_email_field_form(self):
+        Field = modelform_factory(models.FieldPlugin, forms.EmailFieldForm, exclude=(
+            'email_send_notification', 'email_body', 'email_subject'))
+        self._test_not_unique_field_name(Field())
+
+    def test_file_field_form(self):
+        Field = modelform_factory(models.FieldPlugin, forms.FileFieldForm, exclude=('upload_to', 'max_size'))
+        self._test_not_unique_field_name(Field())
+
+    def test_image_field_form(self):
+        Field = modelform_factory(models.FieldPlugin, forms.ImageFieldForm, exclude=(
+            'max_width', 'max_size', 'upload_to', 'max_height'))
+        self._test_not_unique_field_name(Field())
+
+    def test_text_area_field_form(self):
+        Field = modelform_factory(models.FieldPlugin, forms.TextAreaFieldForm, exclude=(
+            'text_area_columns', 'text_area_rows'))
+        self._test_not_unique_field_name(Field())
+
+    def test_multiple_select_field_form(self):
+        Field = modelform_factory(models.FieldPlugin, forms.MultipleSelectFieldForm)
+        self._test_not_unique_field_name(Field())

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,12 +2,12 @@
 from __future__ import division, print_function, unicode_literals
 
 from django.db import IntegrityError
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 
 from cms.api import add_plugin
 from cms.models import Placeholder
 
-from aldryn_forms.models import Option
+from aldryn_forms.models import FieldPluginBase, Option
 
 
 class OptionTestCase(TestCase):
@@ -90,3 +90,10 @@ class OptionTestCase(TestCase):
         self.assertEquals(option1.position, 960)  # We force a value for it on Option.save
 
         self.assertRaises(IntegrityError, Option.objects.update, position=None)  # See? Not nullable
+
+
+class FieldPluginBaseTest(SimpleTestCase):
+
+    def test_field_plugin_base(self):
+        obj = FieldPluginBase()
+        self.assertTrue(obj.unique_field_name)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,12 +1,18 @@
+from django.contrib.messages.storage.base import BaseStorage
 from django.core.exceptions import ImproperlyConfigured
 from django.test import override_settings
 from django.utils.translation import ugettext_lazy as _
 
+from cms.api import add_plugin, create_page
+from cms.operations import MOVE_PLUGIN, PASTE_PLUGIN
 from cms.test_utils.testcases import CMSTestCase
 
 from aldryn_forms.action_backends import DefaultAction, EmailAction, NoAction
 from aldryn_forms.action_backends_base import BaseAction
-from aldryn_forms.utils import action_backend_choices, get_action_backends
+from aldryn_forms.utils import (
+    action_backend_choices, find_plugin_form, get_action_backends,
+    get_form_fields_names, rename_field_name,
+)
 
 
 class FakeValidBackend(BaseAction):
@@ -128,3 +134,87 @@ class ActionChoicesTestCase(CMSTestCase):
         choices = action_backend_choices()
 
         self.assertEquals(choices, expected)
+
+
+class RenameFieldName(CMSTestCase):
+
+    def setUp(self):
+        page = create_page('test page', 'test_page.html', 'en')
+        self.placeholder = page.placeholders.get(slot='content')
+
+    def test_find_plugin_form_none(self):
+        self.assertIsNone(find_plugin_form(None))
+
+    def test_find_plugin_form_with_parent(self):
+        parent = add_plugin(self.placeholder, 'PlaceholderPlugin', 'en')
+        filed = add_plugin(parent.placeholder, 'TextField', 'en', target=parent, name="first_name")
+        instance = filed.get_plugin_instance()[0]
+        self.assertIsNone(find_plugin_form(instance.get_parent()))
+
+    def test_find_plugin_form_with_parent_form(self):
+        parent = add_plugin(self.placeholder, 'FormPlugin', 'en')
+        filed = add_plugin(parent.placeholder, 'TextField', 'en', target=parent, name="first_name")
+        instance = filed.get_plugin_instance()[0]
+        self.assertEquals(find_plugin_form(instance.get_parent()).plugin_type, "FormPlugin")
+
+    def test_find_plugin_form_with_parent_emailnotificationform(self):
+        parent = add_plugin(self.placeholder, 'EmailNotificationForm', 'en')
+        filed = add_plugin(parent.placeholder, 'TextField', 'en', target=parent, name="first_name")
+        instance = filed.get_plugin_instance()[0]
+        self.assertEquals(find_plugin_form(instance.get_parent()).plugin_type, "EmailNotificationForm")
+
+    def _create_form_with_fields(self, name="email"):
+        form = add_plugin(self.placeholder, 'FormPlugin', 'en')
+        add_plugin(form.placeholder, 'TextField', 'en', target=form, name="first_name")
+        add_plugin(form.placeholder, 'TextField', 'en', target=form, name="last_name")
+        email = add_plugin(form.placeholder, 'EmailField', 'en', target=form, name=name)
+        descendant = add_plugin(form.placeholder, 'PlaceholderPlugin', 'en', target=form)
+        add_plugin(descendant.placeholder, 'TextField', 'en', target=descendant, name="is_holder")
+        return (form, email)
+
+    def test_get_form_fields_names(self):
+        form, email = self._create_form_with_fields()
+        names = get_form_fields_names(email.get_plugin_instance()[0], form)
+        self.assertEquals(names, ['first_name', 'last_name', 'is_holder'])
+
+    def _create_form_and_field(self, name="email"):
+        form, dummy_email = self._create_form_with_fields()
+        other_email = add_plugin(self.placeholder, 'EmailField', 'en', target=form, name=name)
+        return (form, other_email)
+
+    def test_rename_field_name_operation_none(self):
+        form, other_email = self._create_form_and_field()
+        rename_field_name(self.get_request(), None, other_email)
+        self.assertEquals(other_email.name, 'email')
+
+    def test_rename_field_name_move_plugin_with_unequal_name(self):
+        form, other_email = self._create_form_and_field('email-2')
+        rename_field_name(self.get_request(), MOVE_PLUGIN, other_email)
+        self.assertEquals(other_email.name, 'email-2')
+
+    def test_rename_field_name_move_plugin(self):
+        form, other_email = self._create_form_and_field()
+        rename_field_name(self.get_request(), MOVE_PLUGIN, other_email)
+        self.assertEquals(other_email.name, 'email_')
+
+    def test_rename_field_name_move_plugin_name_with_suffix(self):
+        form, dummy_email = self._create_form_with_fields('email_')
+        other_email = add_plugin(self.placeholder, 'EmailField', 'en', target=form, name='email_')
+        rename_field_name(self.get_request(), MOVE_PLUGIN, other_email)
+        self.assertEquals(other_email.name, 'email__')
+
+    def test_rename_field_name_paste_plugin(self):
+        form, other_email = self._create_form_and_field()
+        rename_field_name(self.get_request(), PASTE_PLUGIN, other_email)
+        self.assertEquals(other_email.name, 'email_')
+
+    def test_rename_field_name_message(self):
+        form, other_email = self._create_form_and_field()
+        request = self.get_request()
+        request._messages = BaseStorage(request)
+        rename_field_name(request, MOVE_PLUGIN, other_email)
+        self.assertEquals(other_email.name, 'email_')
+        messages = [msg.message for msg in request._messages._queued_messages]
+        self.assertEquals(messages, [
+            "The field 'email' has been renamed to 'email_', because such a name is already in the form."
+        ])


### PR DESCRIPTION
If a user enters a field with a name that already exists in the form, it throws an exception `KeyError`. You need to prevent the user from entering such a name.

New behavior:
 * Add plugin: Rename field name if it is not unique on the form.
 * Change plulgin: Do not allow to save form with duplicate name.
 * Move plugin: Rename field name if it is not unique on the form.
 * Paste plugin: Rename field name if it is not unique on the form.
